### PR TITLE
Fixed an issue where pressing on Remove Tape would infinitely decrease a counter

### DIFF
--- a/main.js
+++ b/main.js
@@ -91,6 +91,7 @@ var app = new Vue({
 
     remove_tape() {
       this.n_tapes -= 1
+      if(this.n_tapes <=0) this.n_tapes = 0
       this.$delete(this.tapes, this.n_tapes)
     },
 


### PR DESCRIPTION
Previously, if you continued to press the Remove Tape button, you would need to press Add Tape the same amount of times before it actually adds it. 